### PR TITLE
feat: add security headers to CF distribution

### DIFF
--- a/customHttp.yml
+++ b/customHttp.yml
@@ -1,0 +1,15 @@
+applications:
+  - appRoot: packages/app
+    customHeaders:
+      - pattern: '**/*'
+        headers:
+          - key: 'Strict-Transport-Security'
+            value: 'max-age=31536000; includeSubDomains'
+          - key: 'X-Frame-Options'
+            value: 'SAMEORIGIN'
+          - key: 'X-XSS-Protection'
+            value: '1; mode=block'
+          - key: 'X-Content-Type-Options'
+            value: 'nosniff'
+          - key: 'Content-Security-Policy'
+            value: "default-src 'self'"


### PR DESCRIPTION
## Description

Adds security headers to CloudFront distribution for frontend

https://docs.aws.amazon.com/amplify/latest/userguide/custom-headers.html#example-security-headers