### PR TITLE
fix(builder): import regex to not transform "discord.js"

### DIFF
--- a/packages/builder/index.js
+++ b/packages/builder/index.js
@@ -6,7 +6,7 @@ const glob = require('tiny-glob')
 let transformJsImportToCjsPlugin = {
   name: 'transform-js-import-to-cjs',
   setup(build) {
-    build.onResolve({ filter: /\.js$/ }, (args) => {
+    build.onResolve({ filter: /^.[./].+([A-z0-9-_])?\.js$/ }, (args) => {
       if (args.importer)
         return { path: args.path.slice(0, -3) + '.cjs', external: true }
     })


### PR DESCRIPTION
Fixes regex to not transform package imports with names like `discord.js` to `discord.cjs`. Previously regex was looking for the `.js` file extension to transform.

![image](https://user-images.githubusercontent.com/5033303/147485300-f25997df-2b1f-4bee-83b9-9a146cb3e036.png)
