### PR TITLE
feat: add support package

### DIFF
--- a/packages/support/package.json
+++ b/packages/support/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@hey-amplify/support",
+  "type": "module",
+  "version": "0.0.1",
+  "license": "Apache-2.0",
+  "decription": "",
+  "exports": {
+    ".": {
+      "import": "./build/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "vite build",
+    "dev": "pnpm build -- --watch",
+    "clean": "rimraf build",
+    "prepublishOnly": "pnpm build"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@aws-sdk/client-ssm": "^3.53.0",
+    "@hey-amplify/tsconfig": "workspace:*",
+    "fast-glob": "^3.2.11",
+    "rimraf": "^3.0.2",
+    "typescript": "next",
+    "vite": "^2.9.1",
+    "vitest": "^0.8.2"
+  }
+}

--- a/packages/support/readme.md
+++ b/packages/support/readme.md
@@ -1,0 +1,3 @@
+# @hey-amplify/support
+
+Support package for hey-amplify resources intended for local/init only

--- a/packages/support/src/index.ts
+++ b/packages/support/src/index.ts
@@ -1,0 +1,19 @@
+import { access, readFile } from 'node:fs/promises'
+import { resolve } from 'node:path'
+
+export async function exists(path) {
+  try {
+    await access(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export async function readJSON(path) {
+  if (!exists(path)) throw new Error(`File ${path} does not exist`)
+  const content = await readFile(path, 'utf8')
+  return JSON.parse(content)
+}
+
+export * from './secrets'

--- a/packages/support/src/secrets.ts
+++ b/packages/support/src/secrets.ts
@@ -1,0 +1,118 @@
+import {
+  SSMClient,
+  GetParametersByPathCommand,
+  GetParameterCommand,
+  PutParameterCommand,
+} from '@aws-sdk/client-ssm'
+import { loadEnv } from 'vite'
+import type { PutParameterCommandInput } from '@aws-sdk/client-ssm'
+
+const PROJECT_NAME = 'hey-amplify'
+// TODO: interpolate environment name in place of 'env'
+const PREFIX = `/app/hey-amplify/env/secret/`
+const REGION = process.env.REGION || 'us-east-1'
+
+export function loadSecrets(
+  envDir: string = new URL('../../', import.meta.url).pathname,
+  envPrefix: string | string[] = 'DISCORD_'
+): Record<string, string> {
+  const prefixes = Array.isArray(envPrefix) ? envPrefix : [envPrefix]
+  return loadEnv('development', envDir, prefixes)
+}
+
+export async function getSecretsFromSSM() {
+  try {
+    const client = new SSMClient({ region: REGION })
+    const command = new GetParametersByPathCommand({
+      Path: PREFIX,
+      WithDecryption: true,
+    })
+    const { Parameters } = await client.send(command)
+
+    if (!Parameters.length) {
+      throw new Error('No secrets found')
+    }
+
+    return Parameters
+  } catch (error) {
+    console.error(error)
+    throw new Error(`Unable to get secrets: ${error.message}`)
+  }
+}
+
+export async function getSecrets() {
+  const secrets = await getSecretsFromSSM()
+  const result = {}
+
+  for (const secret of secrets) {
+    const key = secret.Name.replace(PREFIX, '')
+    result[key] = secret.Value
+  }
+
+  return result
+}
+
+export async function createSecrets() {
+  /**
+   * @type {import('@aws-sdk/client-ssm').SSMClient}
+   */
+  const client = new SSMClient({ region: REGION })
+
+  const secretsPrefix = PREFIX
+  const parameters = {
+    created: [],
+    updated: [],
+    unchanged: [],
+  }
+
+  // TODO: delete unused variables as they're removed from .env?
+  const secrets = Object.entries(loadSecrets())
+  if (!secrets.length) process.exit(0)
+  for (let [key, value] of secrets) {
+    const Name = `${secretsPrefix}/${key}`
+    const Tags = [{ Key: 'app-name', Value: PROJECT_NAME }]
+
+    const putParameterInput: PutParameterCommandInput = {
+      Type: 'SecureString',
+      Name,
+      Value: value,
+    }
+
+    let existing
+    try {
+      existing = await client.send(
+        new GetParameterCommand({ Name, WithDecryption: true })
+      )
+    } catch (error) {
+      // ignore
+    }
+    if (existing) {
+      // update
+      if (existing.Parameter.Value !== value) {
+        putParameterInput.Overwrite = true
+        try {
+          await client.send(new PutParameterCommand(putParameterInput))
+          parameters.updated.push(key)
+        } catch (error) {
+          console.error(error)
+        }
+      } else {
+        parameters.unchanged.push(key)
+      }
+      // TODO: update/add tags
+    } else {
+      // create
+      putParameterInput.Tags = Tags
+      try {
+        await client.send(new PutParameterCommand(putParameterInput))
+        parameters.created.push(key)
+      } catch (error) {
+        // swallow error if parameter exists
+        // if (error.name === 'ParameterAlreadyExists') {
+        //   continue
+        // }
+        console.error(error)
+      }
+    }
+  }
+}

--- a/packages/support/tsconfig.json
+++ b/packages/support/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@hey-amplify/tsconfig/base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build",
+    "noImplicitAny": false,
+    "isolatedModules": true,
+    "types": ["vite/client"]
+  },
+  "exclude": ["build", "bin", "node_modules"]
+}

--- a/packages/support/vite.config.ts
+++ b/packages/support/vite.config.ts
@@ -1,5 +1,5 @@
 import * as fs from 'node:fs/promises'
-import { defineConfig, loadEnv } from 'vite'
+import { defineConfig } from 'vite'
 import glob from 'fast-glob'
 
 const pkg = JSON.parse(
@@ -9,8 +9,6 @@ const pkg = JSON.parse(
 const input = await glob('src/**/!(*.d).(js|ts)')
 
 export default defineConfig({
-  // envPrefix: 'DISCORD_',
-  envDir: '../../',
   build: {
     target: 'esnext',
     sourcemap: true,
@@ -18,7 +16,7 @@ export default defineConfig({
     ssr: true,
     lib: {
       entry: './src/index.ts',
-      name: 'cdk-construct',
+      name: 'support',
       formats: ['es'],
       fileName: (format) => `[name].js`,
     },

--- a/packages/support/vite.config.ts
+++ b/packages/support/vite.config.ts
@@ -1,0 +1,36 @@
+import * as fs from 'node:fs/promises'
+import { defineConfig, loadEnv } from 'vite'
+import glob from 'fast-glob'
+
+const pkg = JSON.parse(
+  await fs.readFile(new URL('package.json', import.meta.url).pathname, 'utf8')
+)
+
+const input = await glob('src/**/!(*.d).(js|ts)')
+
+export default defineConfig({
+  // envPrefix: 'DISCORD_',
+  envDir: '../../',
+  build: {
+    target: 'esnext',
+    sourcemap: true,
+    outDir: 'build',
+    ssr: true,
+    lib: {
+      entry: './src/index.ts',
+      name: 'cdk-construct',
+      formats: ['es'],
+      fileName: (format) => `[name].js`,
+    },
+    rollupOptions: {
+      input,
+      external: Object.keys(pkg.dependencies),
+      output: {
+        inlineDynamicImports: false,
+        preserveModules: true,
+        preserveModulesRoot: 'src',
+      },
+    },
+  },
+  plugins: [],
+})


### PR DESCRIPTION
## Description

Migrates logic from Amplify hooks to a dedicated support package

- loads secrets from dotenv using vite-provided `loadEnv`
- gets secrets from SSM by prefix
- creates secrets in SSM from local dotenv
- adds `exists` helper
- adds `readJson` helper